### PR TITLE
Fix for fail finding grep in C:\Git\bin\grep.exe

### DIFF
--- a/counsel-etags.el
+++ b/counsel-etags.el
@@ -353,15 +353,15 @@ The file is also used by tags file auto-update process.")
   "Guess path from its EXECUTABLE-NAME on Windows.
 Return nil if it's not found."
   (cond
+   (t
+    (if (executable-find executable-name) (executable-find executable-name)))
    ((eq system-type 'windows-nt)
     (or (counsel-etags-win-path executable-name "c")
         (counsel-etags-win-path executable-name "d")
         (counsel-etags-win-path executable-name "e")
         (counsel-etags-win-path executable-name "f")
         (counsel-etags-win-path executable-name "g")
-        (counsel-etags-win-path executable-name "h")))
-   (t
-    (if (executable-find executable-name) (executable-find executable-name)))))
+        (counsel-etags-win-path executable-name "h")))))
 
 ;;;###autoload
 (defun counsel-etags-version ()


### PR DESCRIPTION
First of all, thanks for your work!

I recently updated counsel-etags. This update was causing counsel-etags-grep to fail with message `/usr/bin/bash.exe: nil Command not found`. So it seemed that for some reason counsel-etags was not finding a suitable grep/ag/rg. This was odd, because prior to the update it was found, and nothing else changed in my system.

I inspected this further and traced it back to (counsel-etags-guess-program), which in windows was looking for the executable only in Cygwin folders. I am using git's grep for windows and I don't even have Cygwin.

So I changed (counsel-etags-guess-program) to look first in the system path, and do the Cygwin search only if this fails. Don't know if this is correct, but at least fixes my problem. HTH.