### PR TITLE
fix doc on package install

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@ It's been tested on Linux/Windows/macOS.
 
 [[file:demo.png]]
 * Install
-You can install =counsel-etags= from [[https://melpa.org/#/counsel-etags][MELPA]] with =package.el= (=M-x package-install git-gutter=).
+You can install =counsel-etags= from [[https://melpa.org/#/counsel-etags][MELPA]] with =package.el= (=M-x package-install counsel-etags=).
 
 If "Exuberant Ctags" (some people prefer "Universal Ctags" because it's more actively maintained) exists, this program works out of box.
 


### PR DESCRIPTION
There is a typo in the README on the `package install` instruction referring to `git-gutter` instead of `counsel-etags`. This PR corrects that.