### PR TITLE
Adds async ripgrep (via counsel-rg) and ivy action "g" to switch to grep from tag search

### DIFF
--- a/counsel-etags.el
+++ b/counsel-etags.el
@@ -107,6 +107,9 @@
 ;;  - `counsel-etags-find-tag-name-function' finds tag name at point.  If it returns nil,
 ;;    `find-tag-default' is used.  `counsel-etags-word-at-point' gets word at point.
 ;;
+;;  - `counsel-etags-fallback-search-function' is used as fallback search function. Set to
+;;    `counsel-etags-async-ripgrep' for a non-blocking alternative. Handy for large codebases.
+;;
 ;;  - User could append the extra content into tags file in `counsel-etags-after-update-tags-hook'.
 ;;    The parameter of hook is full path of the tags file.  `counsel-etags-tags-line' is a tool function
 ;;    to help user
@@ -476,16 +479,19 @@ The function has same parameters as `counsel-etags-scan-dir-internal'."
 
 (defcustom counsel-etags-fallback-search-function
   'counsel-etags-grep
-  "When tag not found in TAGS, use this search fallback function.")
+  "When tag not found in TAGS, use this search fallback function."
+  :group 'counsel-etags
+  :type 'function)
 
 (defcustom counsel-etags-find-tag-grep-action-key "g"
-  "Key binding to switch to grep via `ivy-dispatching-done'.")
+  "Single-key binding to switch to grep via `ivy-dispatching-done'."
+  :group 'counsel-etags
+  :type 'string)
 
 (defcustom counsel-etags-find-tag-grep-action-title "grep"
-  "Key binding title to switch to grep via `ivy-dispatching-done'.")
-
-(defcustom counsel-etags-find-tag-grep-action-prompt "grep: "
-  "Counsel prompt when grep initiated via `ivy-dispatching-done'.")
+  "Key binding title to switch to grep via `ivy-dispatching-done'."
+  :group 'counsel-etags
+  :type 'string)
 
 (defconst counsel-etags-no-project-msg
   "No project found.  You can create tags file using `counsel-etags-scan-code'.
@@ -1199,7 +1205,7 @@ Focus on TAGNAME if it's not nil."
                        `((,counsel-etags-find-tag-grep-action-key
                           (lambda (x)
                             (funcall counsel-etags-fallback-search-function
-                                     ,tagname ,counsel-etags-find-tag-grep-action-prompt))
+                                     ,tagname))
                           ,counsel-etags-find-tag-grep-action-title)))
       (ivy-read (format  "Find Tag (%s): "
                          (counsel-etags--time-cost time))
@@ -1677,7 +1683,7 @@ ROOT is root directory to grep."
                                (format "-g=!%s" e))
                              counsel-etags-ignore-filenames " "))))
 
-    ;; Momentarily override `counsel-git-grep-action'. Use `counsel-etags-open-file-api'
+    ;; Momentarily override `counsel-git-grep-action'. Use `counsel-etags-open-file-api' instead.
     (cl-letf (((symbol-function 'counsel-git-grep-action) `(lambda (item)
                                                              ;; when grepping, we grepping in project root
                                                              (counsel-etags-open-file-api item


### PR DESCRIPTION
First of, thanks for counsel-etags. It's wonderful and simplifies lots.

Unsure if these are of interest, but here are a couple of features I found handy.

### async ripgrep (via counsel-etags-async-ripgrep).

This is using counsel-rg as a fallback grepping function. A couple of benefits:

1. counsel-rg is non-blocking, which helps on really large codebases or slow filesystems (Emacs would block for up to 6 seconds at times).
2. counsel-rg can receive additional flags (like --glob README).

To use _counsel-etags-async-ripgrep_ as a fallback, set _counsel-etags-fallback-search-function_ to it.

![counsel-grep-async](https://user-images.githubusercontent.com/8107219/84580184-99978880-adcc-11ea-8ab7-e9dc0f6d8305.gif)

### grep ivy action

Addingg another ivy action to be able to switch from tag narrowing to grepping. Ivy actions are typically available via M-o. The grep option is available via "g" key, but can be configured via _counsel-etags-find-tag-grep-action-key_. It's title can also be changed with _counsel-etags-find-tag-grep-action-title_.

![counsel-grep-action](https://user-images.githubusercontent.com/8107219/84580347-1ecf6d00-adce-11ea-8776-35db07148990.gif)
