### PR TITLE
absolute path inside TAGS file

### DIFF
--- a/counsel-etags.el
+++ b/counsel-etags.el
@@ -189,7 +189,7 @@ not exist, it is replaced (silently) with an empty string.
 Symbol location inside tags file should use absolute path.
 A CLI to create tags file:
 
-  find /usr/include | ctags -e -L -"
+  find /usr/include | ctags -e -L --tag-relative=never -"
   :group 'counsel-etags
   :type '(repeat 'string))
 
@@ -791,7 +791,7 @@ If CODE-FILE is a real file, the command scans it and output to stdout."
      ;; Use ctags only
      (ctags-program
       (setq cmd
-            (format "%s %s %s -e %s %s %s -R %s"
+            (format "%s %s %s -e %s %s %s -R %s --tag-relative=never"
                     ctags-program
                     (mapconcat (lambda (p)
                                  (format "--exclude=\"*/%s/*\" --exclude=\"%s/*\""


### PR DESCRIPTION
Since the symbol location inside TAGS file should use absolute path, while in etags mode (see the `ctags -e` option), the default is `relative`.

`--tag-relative=never` option can be added to fix this.

Reference:
- https://docs.ctags.io/en/latest/man/ctags.1.html