### PR TITLE
修复笔误，缺少双引号

### DIFF
--- a/counsel-etags.el
+++ b/counsel-etags.el
@@ -514,7 +514,7 @@ Return nil if it's not found."
 ;;;###autoload
 (defun counsel-etags-version ()
   "Return version."
-  (message "2.0.4))
+  (message "2.0.4"))
 
 ;;;###autoload
 (defun counsel-etags-get-hostname ()


### PR DESCRIPTION
修复counsel-etags首次跳转卡顿问题时，counsel-etags-version函数中多删了双引号，提交pr修复